### PR TITLE
prevent AWS firewall instances from being recreated every 'terraform apply'

### DIFF
--- a/aws_two_tier/aws_two_tier.tf
+++ b/aws_two_tier/aws_two_tier.tf
@@ -232,13 +232,6 @@ resource "aws_instance" "FWInstance" {
   ami = "${var.PANFWRegionMap[var.aws_region]}"
   instance_type = "m4.xlarge"
 
-  ebs_block_device {
-    device_name = "/dev/xvda"
-    volume_type = "gp2"
-    delete_on_termination = true
-    volume_size = 60
-  }
-
   key_name = "${var.ServerKeyName}"
   monitoring = false
 

--- a/one-click-multi-cloud/one-click-aws/aws_two_tier.tf
+++ b/one-click-multi-cloud/one-click-aws/aws_two_tier.tf
@@ -232,13 +232,6 @@ resource "aws_instance" "FWInstance" {
   ami = "${var.PANFWRegionMap[var.aws_region]}"
   instance_type = "m4.xlarge"
 
-  ebs_block_device {
-    device_name = "/dev/xvda"
-    volume_type = "gp2"
-    delete_on_termination = true
-    volume_size = 60
-  }
-
   key_name = "${var.ServerKeyName}"
   monitoring = false
 


### PR DESCRIPTION
Spinning up individual Palo Alto instances by cherry-picking the "FWInstance" resource from this code results in successful 'terraform apply' on the first run. However, on all subsequent runs terraform wants to destroy the instance and re-create it, even if nothing has changed. I found that removing the hard-coded EBS volume and allowing the AMI to provide the EBS details as needed results in subsequent 'terraform apply' commands completing successfully while leaving existing firewall instances in place.

This PR contains the removal of the EBS code wherever found in this repo. The intent is to enable other developers who would like to use this terraform code to avoid this destroy-and-recreate cycle.

I have tested that a single instance of Firewall Bundle 2 spun up without this EBS code in place bootstraps correctly as expected (including an inline PAN-OS upgrade), but I have not personally regression tested this change against all possible iterations of this repo.