### PR TITLE
Updated AMI Values that fix bug #24 issue

### DIFF
--- a/aws_two_tier/aws_vars.tf
+++ b/aws_two_tier/aws_vars.tf
@@ -10,22 +10,23 @@ variable "StackName" {}
 variable "fw_instance_size" {}
 variable "PANFWRegionMap" {
   type = "map"
+  description = "panos byol 8.1.9.x version dated 08-14-2019"
   default =
     {
-      "us-west-2" = "ami-d424b5ac",
-      "ap-northeast-1" =   "ami-57662d31",
-      "us-west-1"      =   "ami-a95b4fc9",
-      "ap-northeast-2" =   "ami-49bd1127",
-      "ap-southeast-1" =   "ami-27baeb5b",
-      "ap-southeast-2" =   "ami-00d61562",
-      "eu-central-1"   =   "ami-55bfd73a",
-      "eu-west-1"      =   "ami-a95b4fc9",
-      "eu-west-2"      =   "ami-876a8de0",
-      "sa-east-1"      =   "ami-9c0154f0",
-      "us-east-1"      =   "ami-a2fa3bdf",
-      "us-east-2"      =   "ami-11e1d774",
-      "ca-central-1"   =   "ami-64038400",
-      "ap-south-1"     =   "ami-e780d988"
+      "us-west-2"      =   "ami-01d3cf1cef1a0ad21",
+      "ap-northeast-1" =   "ami-09bd7cdf45d0d71cd",
+      "us-west-1"      =   "ami-04729560f2c6ec8b4",
+      "ap-northeast-2" =   "ami-0adcb0cda3a791f03",
+      "ap-southeast-1" =   "ami-0bdecbb021a4d989e",
+      "ap-southeast-2" =   "ami-0ab6e099e1d1883a6",
+      "eu-central-1"   =   "ami-023f9c215463e0822",
+      "eu-west-1"      =   "ami-02cb9d170823ba747",
+      "eu-west-2"      =   "ami-0466c0476b48f39dd",
+      "sa-east-1"      =   "ami-0ecc83c824ea77377",
+      "us-east-1"      =   "ami-058c36656fb0ee806",
+      "us-east-2"      =   "ami-081445037ad293033",
+      "ca-central-1"   =   "ami-09d8202b9a1ccdd5d",
+      "ap-south-1"     =   "ami-07c3a22f080d7c830"
     }
 }
 variable "WebServerRegionMap" {
@@ -47,20 +48,21 @@ variable "WebServerRegionMap" {
 
 variable "UbuntuRegionMap" {
   type = "map"
+  description = "ubuntu xenial image version 16.04 dated 11-14-2019"
   default = {
-  "us-west-2"      =  "ami-efd0428f",
-      "ap-northeast-1" =  "ami-afb09dc8",
-      "us-west-1"      =  "ami-2afbde4a",
-      "ap-northeast-2" =  "ami-66e33108",
-      "ap-southeast-1" =  "ami-8fcc75ec",
-      "ap-southeast-2" =  "ami-96666ff5",
-      "eu-central-1"   =  "ami-060cde69",
-      "eu-west-1"      =  "ami-a8d2d7ce",
-      "eu-west-2"      =  "ami-f1d7c395",
-      "sa-east-1"      =  "ami-4090f22c",
-      "us-east-1"      =  "ami-80861296",
-      "us-east-2"      =  "ami-618fab04",
-      "ca-central-1"   =  "ami-b3d965d7",
-      "ap-south-1"     =  "ami-c2ee9dad"
+      "us-west-2"      =  "ami-0bbe9b07c5fe8e86e",
+      "ap-northeast-1" =  "ami-014cc8d7cb6d26dc8",
+      "us-west-1"      =  "ami-0c0e5a396959508b0",
+      "ap-northeast-2" =  "ami-004b3430b806f3b1a",
+      "ap-southeast-1" =  "ami-08b3278ea6e379084",
+      "ap-southeast-2" =  "ami-00d7116c396e73b04",
+      "eu-central-1"   =  "ami-0062c497b55437b01",
+      "eu-west-1"      =  "ami-0987ee37af7792903",
+      "eu-west-2"      =  "ami-05945867d79b7d926",
+      "sa-east-1"      =  "ami-0fb487b6f6ab53ff4",
+      "us-east-1"      =  "ami-09f9d773751b9d606",
+      "us-east-2"      =  "ami-0891395d749676c2e",
+      "ca-central-1"   =  "ami-0086bcfbab4b22f60",
+      "ap-south-1"     =  "ami-0f59afa4a22fad2f0"
   }
 }

--- a/aws_two_tier/aws_vars.tf
+++ b/aws_two_tier/aws_vars.tf
@@ -31,18 +31,21 @@ variable "PANFWRegionMap" {
 }
 variable "WebServerRegionMap" {
   type = "map"
+  description = "amazon linux ami amzn-ami-hvm-2018.03.0.20190826-x86_64-gp2 released on 08-26-2019"
   default = {
-    "us-east-1"        = "ami-1ecae776",
-    "us-east-2"        = "ami-c55673a0",
-    "us-west-2"        = "ami-e7527ed7",
-    "us-west-1"        = "ami-d114f295",
-    "eu-west-1"        = "ami-a10897d6",
-    "eu-central-1"     = "ami-a8221fb5",
-    "ap-northeast-1"   = "ami-cbf90ecb",
-    "ap-southeast-1"   = "ami-68d8e93a",
-    "ap-southeast-2"   = "ami-fd9cecc7",
-    "sa-east-1"        = "ami-b52890a8",
-    "cn-north-1"       = "ami-f239abcb"
+    "us-east-1"        = "ami-00eb20669e0990cb4",
+    "us-east-2"        = "ami-0c64dd618a49aeee8",
+    "us-west-2"        = "ami-08d489468314a58df",
+    "us-west-1"        = "ami-0bce08e823ed38bdd",
+    "eu-west-1"        = "ami-028188d9b49b32a80",
+    "eu-west-2"        = "ami-04de2b60dd25fbb2e",
+    "eu-central-1"     = "ami-010fae13a16763bb4",
+    "ap-northeast-1"   = "ami-0ab3e16f9c414dee7",
+    "ap-southeast-1"   = "ami-05c859630889c79c8",
+    "ap-southeast-2"   = "ami-07cc15c3ba6f8e287",
+    "sa-east-1"        = "ami-0e2c2c29d8017dd99",
+    "ca-central-1"     = "ami-04070f04f450607dc",
+    "ap-south-1"       = "ami-02913db388613c3e1"
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I updated the AMI values for palo fw, webserver, ubuntu server with most recent versions.  Details of exact versions are also included in the code.  

<!--- Describe your changes in detail -->
following ami updates made:
panos byol 8.1.9.x version dated 08-14-2019
ubuntu xenial image version 16.04 dated 11-14-2019
amazon linux ami amzn-ami-hvm-2018.03.0.20190826-x86_64-gp2 released on 08-26-2019

## Motivation and Context

<!--- Why is this change required? What problem does it solve? --> 
Bug#24
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/PaloAltoNetworks/terraform-templates/issues/24

## How Has This Been Tested?
Entire terraform template in multiple regions has not been tested, yet all images have been verified via the aws cli and are valid/consistent ami id.  

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here -->

## Types of changes

<!--- What types of changes does your code introduce? -->
allows code to run as there are now valid ami.  current var references non-existent palo alto ami.  so currently non-working code.
<!--- Remove any that don't apply: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
