### PR TITLE
uplifted azure example to use latest azure resource manager

### DIFF
--- a/azure_two_tier_sample/az_two_tier.tf
+++ b/azure_two_tier_sample/az_two_tier.tf
@@ -1,39 +1,49 @@
-# This file defines the various resources that will be deployed against Azure.
+/*
+Using the AzCLI, accept the offer terms prior to deployment. This only
+need to be done once per subscription
+```
+az vm image terms accept --urn paloaltonetworks:vmseries1:bundle2:latest
+```
+*/
+
+provider "azurerm" {
+  version = "=2.13.0"
+  features {}
+}
 
 resource "azurerm_resource_group" "PAN_FW_RG" {
-  name = "${var.resource_group_name}"
-  location = "${var.location}"
+  name = var.resource_group_name
+  location = var.location
 }
 
 resource "azurerm_storage_account" "PAN_FW_STG_AC" {
-  name = "${join("", list(var.StorageAccountName, substr(md5(azurerm_resource_group.PAN_FW_RG.id), 0, 4)))}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
-  location = "${var.location}"
-  account_type = "${var.storageAccountType}"
+  name = join("", list(var.StorageAccountName, substr(md5(azurerm_resource_group.PAN_FW_RG.id), 0, 4)))
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
+  location = var.location
   account_replication_type = "LRS"
   account_tier = "Standard" 
 }
 
 resource "azurerm_public_ip" "PublicIP_0" {
-  name = "${var.fwpublicIPName}"
-  location = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
-  public_ip_address_allocation = "${var.publicIPAddressType}"
-  domain_name_label = "${join("", list(var.FirewallDnsName, substr(md5(azurerm_resource_group.PAN_FW_RG.id), 0, 4)))}"
+  name = var.fwpublicIPName
+  location = var.location
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
+  allocation_method = var.publicIPAddressType
+  domain_name_label = join("", list(var.FirewallDnsName, substr(md5(azurerm_resource_group.PAN_FW_RG.id), 0, 4)))
 }
 
 resource "azurerm_public_ip" "PublicIP_1" {
-  name = "${var.WebPublicIPName}"
-  location = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
-  public_ip_address_allocation = "${var.publicIPAddressType}"
-  domain_name_label = "${join("", list(var.WebServerDnsName, substr(md5(azurerm_resource_group.PAN_FW_RG.id), 0, 4)))}"
+  name = var.WebPublicIPName
+  location = var.location
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
+  allocation_method = var.publicIPAddressType
+  domain_name_label = join("", list(var.WebServerDnsName, substr(md5(azurerm_resource_group.PAN_FW_RG.id), 0, 4)))
 }
 
 resource "azurerm_network_security_group" "PAN_FW_NSG" {
   name                = "DefaultNSG"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
 
   security_rule {
     name                       = "Allow-Outside-From-IP"
@@ -43,7 +53,7 @@ resource "azurerm_network_security_group" "PAN_FW_NSG" {
     protocol                   = "*"
     source_port_range          = "*"
     destination_port_range     = "*"
-    source_address_prefix      = "${var.FromGatewayLogin}"
+    source_address_prefix      = var.FromGatewayLogin
     destination_address_prefix = "*"
   }
 
@@ -55,7 +65,7 @@ resource "azurerm_network_security_group" "PAN_FW_NSG" {
     protocol                   = "*"
     source_port_range          = "*"
     destination_port_range     = "*"
-    source_address_prefix      = "${join("", list(var.IPAddressPrefix, ".0.0/16"))}"
+    source_address_prefix      = join("", list(var.IPAddressPrefix, ".0.0/16"))
     destination_address_prefix = "*"
   }
 
@@ -107,261 +117,273 @@ resource "azurerm_network_security_group" "PAN_FW_NSG" {
     destination_address_prefix = "*"
   }
 
-  tags {
+  tags = {
     environment = "Production"
   }
 }
 
 resource "azurerm_route_table" "PAN_FW_RT_Trust" {
-  name                = "${var.routeTableTrust}"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
+  name                = var.routeTableTrust
+  location            = var.location
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
 
   route {
     name           = "Trust-to-intranetwork"
     address_prefix = "0.0.0.0/0"
     next_hop_type  = "VirtualAppliance"
-    next_hop_in_ip_address = "${join("", list(var.IPAddressPrefix, ".2.4"))}"
+    next_hop_in_ip_address = join("", list(var.IPAddressPrefix, ".2.4"))
   }
 
-  tags {
+  tags = {
     environment = "Production"
   }
 }
 
 resource "azurerm_route_table" "PAN_FW_RT_Web" {
-  name                = "${var.routeTableWeb}"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
+  name                = var.routeTableWeb
+  location            = var.location
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
 
   route {
     name           = "Web-to-Firewall-DB"
-    address_prefix = "${join("", list(var.IPAddressPrefix, ".4.0/24"))}"
+    address_prefix = join("", list(var.IPAddressPrefix, ".4.0/24"))
     next_hop_type  = "VirtualAppliance"
-    next_hop_in_ip_address = "${join("", list(var.IPAddressPrefix, ".2.4"))}"
+    next_hop_in_ip_address = join("", list(var.IPAddressPrefix, ".2.4"))
   }
 
   route {
     name           = "Web-default-route"
     address_prefix = "0.0.0.0/0"
     next_hop_type  = "VirtualAppliance"
-    next_hop_in_ip_address = "${join("", list(var.IPAddressPrefix, ".2.4"))}"
+    next_hop_in_ip_address = join("", list(var.IPAddressPrefix, ".2.4"))
   }
 
-  tags {
+  tags = {
     environment = "Production"
   }
 }
 
 resource "azurerm_route_table" "PAN_FW_RT_DB" {
-  name                = "${var.routeTableDB}"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
+  name                = var.routeTableDB
+  location            = var.location
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
 
   route {
     name           = "DB-to-Firewall-Web"
-    address_prefix = "${join("", list(var.IPAddressPrefix, ".3.0/24"))}"
+    address_prefix = join("", list(var.IPAddressPrefix, ".3.0/24"))
     next_hop_type  = "VirtualAppliance"
-    next_hop_in_ip_address = "${join("", list(var.IPAddressPrefix, ".2.4"))}"
+    next_hop_in_ip_address = join("", list(var.IPAddressPrefix, ".2.4"))
   }
 
   route {
     name           = "DB-default-route"
     address_prefix = "0.0.0.0/0"
     next_hop_type  = "VirtualAppliance"
-    next_hop_in_ip_address = "${join("", list(var.IPAddressPrefix, ".2.4"))}"
+    next_hop_in_ip_address = join("", list(var.IPAddressPrefix, ".2.4"))
   }
 
-  tags {
+  tags =  {
     environment = "Production"
   }
 }
 
 resource "azurerm_virtual_network" "PAN_FW_VNET" {
-  name                = "${join("", list(var.vnetName, substr(md5(azurerm_resource_group.PAN_FW_RG.id), 0, 4)))}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
-  address_space       = ["${join("", list(var.IPAddressPrefix, ".0.0/16"))}"]
-  location            = "${var.location}"
+  name                = join("", list(var.vnetName, substr(md5(azurerm_resource_group.PAN_FW_RG.id), 0, 4)))
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
+  address_space       = [join("", list(var.IPAddressPrefix, ".0.0/16"))]
+  location            = var.location
 
-  tags {
+  tags = {
     environment = "Production"
   }
 }
 
 resource "azurerm_subnet" "PAN_FW_Subnet0" {
-  name           = "${var.subnet0Name}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
-  address_prefix = "${join("", list(var.IPAddressPrefix, ".0.0/24"))}"
-  network_security_group_id = "${azurerm_network_security_group.PAN_FW_NSG.id}"
-  virtual_network_name = "${azurerm_virtual_network.PAN_FW_VNET.name}"
+  name           = var.subnet0Name
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
+  address_prefix = join("", list(var.IPAddressPrefix, ".0.0/24"))
+  virtual_network_name = azurerm_virtual_network.PAN_FW_VNET.name
+}
+
+resource "azurerm_subnet_network_security_group_association" "example" {
+  subnet_id                 = azurerm_subnet.PAN_FW_Subnet0.id
+  network_security_group_id = azurerm_network_security_group.PAN_FW_NSG.id
 }
 
 resource "azurerm_subnet" "PAN_FW_Subnet1" {
-  name           = "${var.subnet1Name}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
-  address_prefix = "${join("", list(var.IPAddressPrefix, ".1.0/24"))}"
-  network_security_group_id = "${azurerm_network_security_group.PAN_FW_NSG.id}"
-  virtual_network_name = "${azurerm_virtual_network.PAN_FW_VNET.name}"
+  name           = var.subnet1Name
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
+  address_prefix = join("", list(var.IPAddressPrefix, ".1.0/24"))
+  virtual_network_name = azurerm_virtual_network.PAN_FW_VNET.name
+}
+
+resource "azurerm_subnet_network_security_group_association" "example1" {
+  subnet_id                 = azurerm_subnet.PAN_FW_Subnet1.id
+  network_security_group_id = azurerm_network_security_group.PAN_FW_NSG.id
 }
 
 resource "azurerm_subnet" "PAN_FW_Subnet3" {
-  name           = "${var.subnet3Name}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
-  address_prefix = "${join("", list(var.IPAddressPrefix, ".3.0/24"))}"
-  virtual_network_name = "${azurerm_virtual_network.PAN_FW_VNET.name}"
+  name           = var.subnet3Name
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
+  address_prefix = join("", list(var.IPAddressPrefix, ".3.0/24"))
+  virtual_network_name = azurerm_virtual_network.PAN_FW_VNET.name
 }
 
 resource "azurerm_subnet" "PAN_FW_Subnet4" {
-  name           = "${var.subnet4Name}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
-  address_prefix = "${join("", list(var.IPAddressPrefix, ".4.0/24"))}"
-  virtual_network_name = "${azurerm_virtual_network.PAN_FW_VNET.name}"
+  name           = var.subnet4Name
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
+  address_prefix = join("", list(var.IPAddressPrefix, ".4.0/24"))
+  virtual_network_name = azurerm_virtual_network.PAN_FW_VNET.name
 }
 
 resource "azurerm_subnet" "PAN_FW_Subnet2" {
-  name           = "${var.subnet2Name}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
-  address_prefix = "${join("", list(var.IPAddressPrefix, ".2.0/24"))}"
-  route_table_id = "${azurerm_route_table.PAN_FW_RT_Trust.id}"
-  virtual_network_name = "${azurerm_virtual_network.PAN_FW_VNET.name}"
+  name           = var.subnet2Name
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
+  address_prefix = join("", list(var.IPAddressPrefix, ".2.0/24"))
+  virtual_network_name = azurerm_virtual_network.PAN_FW_VNET.name
+}
+
+resource "azurerm_subnet_route_table_association" "example2" {
+  subnet_id                 = azurerm_subnet.PAN_FW_Subnet2.id
+  route_table_id            = azurerm_route_table.PAN_FW_RT_Trust.id
 }
 
 resource "azurerm_network_interface" "VNIC0" {
-  name                = "${join("", list("FW", var.nicName, "0"))}"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
+  name                = join("", list("FW", var.nicName, "0"))
+  location            = var.location
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
   depends_on          = ["azurerm_virtual_network.PAN_FW_VNET",
                           "azurerm_public_ip.PublicIP_0"]
 
   ip_configuration {
-    name                          = "${join("", list("ipconfig", "0"))}"
-    subnet_id                     = "${azurerm_subnet.PAN_FW_Subnet0.id}"
+    name                          = join("", list("ipconfig", "0"))
+    subnet_id                     = azurerm_subnet.PAN_FW_Subnet0.id
     private_ip_address_allocation = "static"
-    private_ip_address = "${join("", list(var.IPAddressPrefix, ".0.4"))}"
-    public_ip_address_id = "${azurerm_public_ip.PublicIP_0.id}"
+    private_ip_address = join("", list(var.IPAddressPrefix, ".0.4"))
+    public_ip_address_id = azurerm_public_ip.PublicIP_0.id
   }
 
-  tags {
-    displayName = "${join("", list("NetworkInterfaces", "0"))}"
+  tags = {
+    displayName = join("", list("NetworkInterfaces", "0"))
   }
 }
 
 resource "azurerm_network_interface" "VNIC1" {
-  name                = "${join("", list("FW", var.nicName, "1"))}"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
+  name                = join("", list("FW", var.nicName, "1"))
+  location            = var.location
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
   depends_on          = ["azurerm_virtual_network.PAN_FW_VNET"]
 
   enable_ip_forwarding = true
   ip_configuration {
-    name                          = "${join("", list("ipconfig", "1"))}"
-    subnet_id                     = "${azurerm_subnet.PAN_FW_Subnet1.id}"
+    name                          = join("", list("ipconfig", "1"))
+    subnet_id                     = azurerm_subnet.PAN_FW_Subnet1.id
     private_ip_address_allocation = "static"
-    private_ip_address = "${join("", list(var.IPAddressPrefix, ".1.4"))}"
-    public_ip_address_id = "${azurerm_public_ip.PublicIP_1.id}"
+    private_ip_address = join("", list(var.IPAddressPrefix, ".1.4"))
+    public_ip_address_id = azurerm_public_ip.PublicIP_1.id
   }
 
-  tags {
-    displayName = "${join("", list("NetworkInterfaces", "1"))}"
+  tags =  {
+    displayName = join("", list("NetworkInterfaces", "1"))
   }
 }
 
 resource "azurerm_network_interface" "VNIC2" {
-  name                = "${join("", list("FW", var.nicName, "2"))}"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
+  name                = join("", list("FW", var.nicName, "2"))
+  location            = var.location
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
   depends_on          = ["azurerm_virtual_network.PAN_FW_VNET"]
 
   enable_ip_forwarding = true
   ip_configuration {
-    name                          = "${join("", list("ipconfig", "2"))}"
-    subnet_id                     = "${azurerm_subnet.PAN_FW_Subnet2.id}"
+    name                          = join("", list("ipconfig", "2"))
+    subnet_id                     = azurerm_subnet.PAN_FW_Subnet2.id
     private_ip_address_allocation = "static"
-    private_ip_address = "${join("", list(var.IPAddressPrefix, ".2.4"))}"
+    private_ip_address = join("", list(var.IPAddressPrefix, ".2.4"))
   }
 
-  tags {
-    displayName = "${join("", list("NetworkInterfaces", "2"))}"
+  tags = {
+    displayName = join("", list("NetworkInterfaces", "2"))
   }
 }
 
 resource "azurerm_network_interface" "VNIC0_Web" {
-  name                = "${join("", list("Web", var.nicName, "0"))}"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
+  name                = join("", list("Web", var.nicName, "0"))
+  location            = var.location
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
   depends_on          = ["azurerm_virtual_network.PAN_FW_VNET"]
 
   ip_configuration {
-    name                          = "${join("", list("ipconfig", "3"))}"
-    subnet_id                     = "${azurerm_subnet.PAN_FW_Subnet3.id}"
+    name                          = join("", list("ipconfig", "3"))
+    subnet_id                     = azurerm_subnet.PAN_FW_Subnet3.id
     private_ip_address_allocation = "static"
-    private_ip_address = "${join("", list(var.IPAddressPrefix, ".3.5"))}"
+    private_ip_address = join("", list(var.IPAddressPrefix, ".3.5"))
   }
 
-  tags {
-    displayName = "${join("", list("NetworkInterfaces", "3"))}"
+  tags = {
+    displayName = join("", list("NetworkInterfaces", "3"))
   }
 }
 
 resource "azurerm_network_interface" "VNIC0_DB" {
-  name                = "${join("", list("DB", var.nicName, "0"))}"
-  location            = "${var.location}"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
+  name                = join("", list("DB", var.nicName, "0"))
+  location            = var.location
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
   depends_on          = ["azurerm_virtual_network.PAN_FW_VNET"]
 
   ip_configuration {
-    name                          = "${join("", list("ipconfig", "4"))}"
-    subnet_id                     = "${azurerm_subnet.PAN_FW_Subnet4.id}"
+    name                          = join("", list("ipconfig", "4"))
+    subnet_id                     = azurerm_subnet.PAN_FW_Subnet4.id
     private_ip_address_allocation = "static"
-    private_ip_address = "${join("", list(var.IPAddressPrefix, ".4.5"))}"
+    private_ip_address = join("", list(var.IPAddressPrefix, ".4.5"))
   }
 
-  tags {
-    displayName = "${join("", list("NetworkInterfaces", "4"))}"
+  tags = {
+    displayName = join("", list("NetworkInterfaces", "4"))
   }
 }
 
 
 resource "azurerm_virtual_machine" "PAN_FW_FW" {
-  name                  = "${var.FirewallVmName}"
-  location              = "${var.location}"
-  resource_group_name   = "${azurerm_resource_group.PAN_FW_RG.name}"
-  vm_size               = "${var.FirewallVmSize}"
+  name                  = var.FirewallVmName
+  location              = var.location
+  resource_group_name   = azurerm_resource_group.PAN_FW_RG.name
+  vm_size               = var.FirewallVmSize
 
   depends_on = ["azurerm_network_interface.VNIC0",
                 "azurerm_network_interface.VNIC1",
                 "azurerm_network_interface.VNIC2"
                 ]
   plan {
-    name = "${var.fwSku}"
-    publisher = "${var.fwPublisher}"
-    product = "${var.fwOffer}"
+    name = var.fwSku
+    publisher = var.fwPublisher
+    product = var.fwOffer
   }
 
   storage_image_reference {
-    publisher = "${var.fwPublisher}"
-    offer     = "${var.fwOffer}"
-    sku       = "${var.fwSku}"
+    publisher = var.fwPublisher
+    offer     = var.fwOffer
+    sku       = var.fwSku
     version   = "latest"
   }
 
   storage_os_disk {
-    name          = "${join("", list(var.FirewallVmName, "-osDisk"))}"
+    name          = join("", list(var.FirewallVmName, "-osDisk"))
     vhd_uri       = "${azurerm_storage_account.PAN_FW_STG_AC.primary_blob_endpoint}vhds/${var.FirewallVmName}-${var.fwOffer}-${var.fwSku}.vhd"
     caching       = "ReadWrite"
     create_option = "FromImage"
   }
 
   os_profile {
-    computer_name  = "${var.FirewallVmName}"
-    admin_username = "${var.adminUsername}"
-    admin_password = "${var.adminPassword}"
+    computer_name  = var.FirewallVmName
+    admin_username = var.adminUsername
+    admin_password = var.adminPassword
   }
 
-  primary_network_interface_id = "${azurerm_network_interface.VNIC0.id}"
-  network_interface_ids = ["${azurerm_network_interface.VNIC0.id}",
-                           "${azurerm_network_interface.VNIC1.id}",
-                           "${azurerm_network_interface.VNIC2.id}",
+  primary_network_interface_id = azurerm_network_interface.VNIC0.id
+  network_interface_ids = [azurerm_network_interface.VNIC0.id,
+                           azurerm_network_interface.VNIC1.id,
+                           azurerm_network_interface.VNIC2.id,
                           ]
 
   os_profile_linux_config {
@@ -370,18 +392,18 @@ resource "azurerm_virtual_machine" "PAN_FW_FW" {
 }
 
 resource "azurerm_virtual_machine" "PAN_FW_Web" {
-  name                  = "${var.web-vm-name}"
-  location              = "${var.location}"
-  resource_group_name   = "${azurerm_resource_group.PAN_FW_RG.name}"
-  vm_size               = "${var.gvmSize}"
+  name                  = var.web-vm-name
+  location              = var.location
+  resource_group_name   = azurerm_resource_group.PAN_FW_RG.name
+  vm_size               = var.gvmSize
 
   depends_on = ["azurerm_network_interface.VNIC0", "azurerm_network_interface.VNIC1",
                   "azurerm_network_interface.VNIC2"]
 
   storage_image_reference {
-    publisher = "${var.imagePublisher}"
-    offer     = "${var.imageOffer}"
-    sku       = "${var.ubuntuOSVersion}"
+    publisher = var.imagePublisher
+    offer     = var.imageOffer
+    sku       = var.ubuntuOSVersion
     version   = "latest"
   }
 
@@ -394,13 +416,13 @@ resource "azurerm_virtual_machine" "PAN_FW_Web" {
 
   os_profile {
     computer_name  = "web-server-vm"
-    admin_username = "${var.adminUsername}"
-    admin_password = "${var.adminPassword}"
+    admin_username = var.adminUsername
+    admin_password = var.adminPassword
   }
 
-  network_interface_ids = ["${azurerm_network_interface.VNIC0_Web.id}"]
+  network_interface_ids = [azurerm_network_interface.VNIC0_Web.id]
 
-  tags {
+  tags = {
     environment = "staging"
   }
 
@@ -410,18 +432,18 @@ resource "azurerm_virtual_machine" "PAN_FW_Web" {
 }
 
 resource "azurerm_virtual_machine" "PAN_FW_DB" {
-  name                  = "${var.db-vm-name}"
-  location              = "${var.location}"
-  resource_group_name   = "${azurerm_resource_group.PAN_FW_RG.name}"
-  vm_size               = "${var.gvmSize}"
+  name                  = var.db-vm-name
+  location              = var.location
+  resource_group_name   = azurerm_resource_group.PAN_FW_RG.name
+  vm_size               = var.gvmSize
 
   depends_on = ["azurerm_network_interface.VNIC0", "azurerm_network_interface.VNIC1",
                   "azurerm_network_interface.VNIC2", "azurerm_network_interface.VNIC0_DB"]
 
   storage_image_reference {
-    publisher = "${var.imagePublisher}"
-    offer     = "${var.imageOffer}"
-    sku       = "${var.ubuntuOSVersion}"
+    publisher = var.imagePublisher
+    offer     = var.imageOffer
+    sku       = var.ubuntuOSVersion
     version   = "latest"
   }
 
@@ -434,13 +456,13 @@ resource "azurerm_virtual_machine" "PAN_FW_DB" {
 
   os_profile {
     computer_name  = "database-vm"
-    admin_username = "${var.adminUsername}"
-    admin_password = "${var.adminPassword}"
+    admin_username = var.adminUsername
+    admin_password = var.adminPassword
   }
 
-  network_interface_ids = ["${azurerm_network_interface.VNIC0_DB.id}"]
+  network_interface_ids = [azurerm_network_interface.VNIC0_DB.id]
 
-  tags {
+  tags = {
     environment = "staging"
   }
 
@@ -451,9 +473,7 @@ resource "azurerm_virtual_machine" "PAN_FW_DB" {
 
 resource "azurerm_virtual_machine_extension" "PAN_FW_DB_EXT" {
   name                 = "db-vm-customscript"
-  location             = "${var.location}"
-  resource_group_name  = "${azurerm_resource_group.PAN_FW_RG.name}"
-  virtual_machine_name = "${azurerm_virtual_machine.PAN_FW_DB.name}"
+  virtual_machine_id = azurerm_virtual_machine.PAN_FW_DB.id
   publisher            = "Microsoft.Azure.Extensions"
   type                 = "CustomScript"
   type_handler_version = "2.0"
@@ -487,9 +507,7 @@ SETTINGS
 
 resource "azurerm_virtual_machine_extension" "PAN_FW_WEB_EXT_MIN" {
   name                 = "web-vm-customscript"
-  location             = "${var.location}"
-  resource_group_name  = "${azurerm_resource_group.PAN_FW_RG.name}"
-  virtual_machine_name = "${azurerm_virtual_machine.PAN_FW_Web.name}"
+  virtual_machine_id   = azurerm_virtual_machine.PAN_FW_Web.id
   publisher            = "Microsoft.Azure.Extensions"
   type                 = "CustomScript"
   type_handler_version = "2.0"
@@ -504,7 +522,7 @@ SETTINGS
 
 resource "azurerm_template_deployment" "DBlinkedTemplate" {
   name                = "DBlinkedTemplate"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
 
   depends_on = [
     "azurerm_virtual_machine_extension.PAN_FW_DB_EXT",
@@ -515,11 +533,11 @@ resource "azurerm_template_deployment" "DBlinkedTemplate" {
     "azurerm_route_table.PAN_FW_RT_Web",
     "azurerm_route_table.PAN_FW_RT_DB"
   ]
-  parameters {
-    name = "${azurerm_virtual_network.PAN_FW_VNET.name}/${azurerm_subnet.PAN_FW_Subnet4.name}"
-    location = "${var.location}"
-    subnet4Prefix = "${join("", list(var.IPAddressPrefix, ".4.0/24"))}"
-    route_table_id = "${azurerm_route_table.PAN_FW_RT_DB.id}"
+  parameters = {
+    name = join("/", list(azurerm_virtual_network.PAN_FW_VNET.name, azurerm_subnet.PAN_FW_Subnet4.name))
+    location = var.location
+    subnet4Prefix = join("", list(var.IPAddressPrefix, ".4.0/24"))
+    route_table_id = azurerm_route_table.PAN_FW_RT_DB.id
   }
 
   template_body = <<DEPLOY
@@ -562,16 +580,16 @@ DEPLOY
 
 resource "azurerm_template_deployment" "WeblinkedTemplate" {
   name                = "WeblinkedTemplate"
-  resource_group_name = "${azurerm_resource_group.PAN_FW_RG.name}"
+  resource_group_name = azurerm_resource_group.PAN_FW_RG.name
 
   depends_on = [
     "azurerm_template_deployment.DBlinkedTemplate"
   ]
-  parameters {
-    name = "${azurerm_virtual_network.PAN_FW_VNET.name}/${azurerm_subnet.PAN_FW_Subnet3.name}"
-    location = "${var.location}"
-    subnet3Prefix = "${join("", list(var.IPAddressPrefix, ".3.0/24"))}"
-    route_table_id = "${azurerm_route_table.PAN_FW_RT_Web.id}"
+  parameters = {
+    name = join("/", list(azurerm_virtual_network.PAN_FW_VNET.name,azurerm_subnet.PAN_FW_Subnet3.name))
+    location = var.location
+    subnet3Prefix = join("", list(var.IPAddressPrefix, ".3.0/24"))
+    route_table_id = azurerm_route_table.PAN_FW_RT_Web.id
   }
 
   template_body = <<DEPLOY
@@ -613,17 +631,17 @@ DEPLOY
 }
 
 output "FirewallIP" {
-  value = "${join("", list("https://", "${azurerm_public_ip.PublicIP_0.ip_address}"))}"
+  value = join("", list("https://", azurerm_public_ip.PublicIP_0.ip_address))
 }
 
 output "FirewallFQDN" {
-  value = "${join("", list("https://", "${azurerm_public_ip.PublicIP_0.fqdn}"))}"
+  value = join("", list("https://", azurerm_public_ip.PublicIP_0.fqdn))
 }
 
 output "WebIP" {
-  value = "${join("", list("http://", "${azurerm_public_ip.PublicIP_1.ip_address}"))}"
+  value = join("", list("http://", azurerm_public_ip.PublicIP_1.ip_address))
 }
 
 output "WebFQDN" {
-  value = "${join("", list("http://", "${azurerm_public_ip.PublicIP_1.fqdn}"))}"
+  value = join("", list("http://", azurerm_public_ip.PublicIP_1.fqdn))
 }


### PR DESCRIPTION
Ive updated the azure-two-tier example code to work with new terraform.

## Description
Ive added network security group associations, subnet route assoications, fixed a lot of outdated syntax and addressed any fields that no longer work.

There is one piece of information that is missing and ive added it as a comment at the top of the file.
You have to manually accept the terms for the PA image. Although, i dont suppose this is anything new, I just couldnt find any mention of it anywhere.

Ive tested the new deployment and it seems to work.

## Motivation and Context
The code hasnt been updated in a couple of years and dosent currently work.

## How Has This Been Tested?
Tested on a fresh environment.
Originally tried to deploy in the UK south region but it failed as the image isnt available there. Switched to westus2 as it originally was and it worked. I had to accept license terms (needs to be done once per subscription) for the PA image.
```
az vm image terms accept --urn paloaltonetworks:vmseries1:bundle2:latest
```

## Screenshots (if appropriate)
Deployment is successful
![image](https://user-images.githubusercontent.com/25075013/83877194-01493600-a732-11ea-92af-f292fbc8ef43.png)

Extensions also deploy successfully
![image](https://user-images.githubusercontent.com/25075013/83877260-2178f500-a732-11ea-9bb7-1e0c9556e629.png)

## Types of changes

-Bug Fix
I havent added any new functionality, ive simply uplifted so that it can succesfully be deployed using the latest terraform and azurerm.

## Checklist

- [x ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
